### PR TITLE
Fix: allow updating product without requiring a new image

### DIFF
--- a/SpringEcom/src/main/java/com/learning/springecom/controller/ProductController.java
+++ b/SpringEcom/src/main/java/com/learning/springecom/controller/ProductController.java
@@ -74,10 +74,14 @@ public class ProductController {
 
 
     @PutMapping("/product/{id}")
-    public ResponseEntity<String> updateProduct(@PathVariable int id, @RequestPart Product product, @RequestPart MultipartFile imageFile) {
-        Product updatedProduct = null;
+    public ResponseEntity<String> updateProduct(
+            @PathVariable int id,
+            @RequestPart Product product,
+            @RequestPart(required = false) MultipartFile imageFile) {
+
         try {
-            updatedProduct = productService.addOrUpdateProduct(product, imageFile);
+            product.setId(id); // Ensure the ID is set
+            Product updatedProduct = productService.addOrUpdateProduct(product, imageFile);
             return new ResponseEntity<>("Updated successfully", HttpStatus.OK);
         } catch (IOException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/SpringEcom/src/main/java/com/learning/springecom/model/Product.java
+++ b/SpringEcom/src/main/java/com/learning/springecom/model/Product.java
@@ -11,30 +11,27 @@ import java.util.Date;
 
 @Entity
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class Product {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
     private String name;
     private String description;
     private String brand;
+    private BigDecimal price;
     private String category;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy")
     private Date releaseDate;
     private boolean productAvailable;
     private int stockQuantity;
-    private BigDecimal price;
     private String imageName;
     private String imageType;
     @Lob
     private byte[] imageData;
 
-    public Product(int id) {
+    public Product(int id){
         this.id = id;
     }
-
 
 }

--- a/SpringEcom/src/main/java/com/learning/springecom/service/ProductService.java
+++ b/SpringEcom/src/main/java/com/learning/springecom/service/ProductService.java
@@ -36,9 +36,20 @@ public class ProductService {
     }
 
     public Product addOrUpdateProduct(Product product, MultipartFile image) throws IOException {
-        product.setImageName(image.getOriginalFilename());
-        product.setImageType(image.getContentType());
-        product.setImageData(image.getBytes());
+        // Only update image fields if a new image is provided
+        if (image != null && !image.isEmpty()) {
+            product.setImageName(image.getOriginalFilename());
+            product.setImageType(image.getContentType());
+            product.setImageData(image.getBytes());
+        } else if (product.getId() > 0) {
+            // For updates, preserve existing image data if no new image provided
+            Product existingProduct = productRepo.findById(product.getId()).orElse(null);
+            if (existingProduct != null) {
+                product.setImageName(existingProduct.getImageName());
+                product.setImageType(existingProduct.getImageType());
+                product.setImageData(existingProduct.getImageData());
+            }
+        }
         return productRepo.save(product);
     }
 

--- a/ecom-frontend-ai/src/components/UpdateProduct.jsx
+++ b/ecom-frontend-ai/src/components/UpdateProduct.jsx
@@ -65,46 +65,49 @@ const UpdateProduct = () => {
     return file;
   }
  
-  const handleSubmit = async(e) => {
+const handleSubmit = async(e) => {
     setLoading(true);
     e.preventDefault();
-    console.log("images", image)
-    console.log("productsdfsfsf", updateProduct)
+    
     const updatedProduct = new FormData();
+    
+    // Only append image if user selected a new one
     if (imageChanged && image) {
-      updatedProduct.append("imageFile", image);
-    } else {
-      // Send null or empty value when no image is selected by user
-      updatedProduct.append("imageFile", null);
+        updatedProduct.append("imageFile", image);
     }
     
+    // Ensure ID is included in the product object
+    const productData = {
+        ...updateProduct,
+        id: parseInt(id) // Ensure ID is set
+    };
+    
     updatedProduct.append(
-      "product",
-      new Blob([JSON.stringify(updateProduct)], { type: "application/json" })
+        "product",
+        new Blob([JSON.stringify(productData)], { type: "application/json" })
     );
-  
 
-  console.log("formData : ", updatedProduct)
-    axios
-      .put(`${baseUrl}/api/product/${id}`, updatedProduct, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      })
-      .then((response) => {
-        console.log("Product updated successfully:", updatedProduct);
-        toast.success("product updated successfully")
-      })
-      .catch((error) => {
+    try {
+        const response = await axios.put(
+            `${baseUrl}/api/product/${id}`, 
+            updatedProduct, 
+            {
+                headers: {
+                    "Content-Type": "multipart/form-data",
+                },
+            }
+        );
+        
+        console.log("Product updated successfully:", response.data);
+        toast.success("Product updated successfully");
+        navigate('/');
+    } catch (error) {
         console.error("Error updating product:", error);
-        console.log("product unsuccessfull update",updateProduct)
         toast.error("Failed to update product. Please try again.");
-      }).finally(()=>{
-        setLoading(false)
-        navigate('/')
-      }
-      );
-  };
+    } finally {
+        setLoading(false);
+    }
+};
  
 
   const handleChange = (e) => {
@@ -223,6 +226,7 @@ const UpdateProduct = () => {
                     <option value="">Select category</option>
                     <option value="Laptop">Laptop</option>
                     <option value="Headphone">Headphone</option>
+                    <option value="Accessories">Accessories</option>
                     <option value="Mobile">Mobile</option>
                     <option value="Electronics">Electronics</option>
                     <option value="Toys">Toys</option>


### PR DESCRIPTION
Previously, updating a product required re-uploading an image.
This fix ensures existing images are preserved unless a new one is uploaded.